### PR TITLE
[REFACTOR] invalid api 추가 및 block api 로직 변경

### DIFF
--- a/src/sportslive/report/application/report_service.py
+++ b/src/sportslive/report/application/report_service.py
@@ -31,6 +31,11 @@ class ReportService:
             cheer_talk.is_blocked = False
         self._cheer_talk_repository.save_cheer_talk(cheer_talk)
 
+    def make_report_invalid(self, report_id: int):
+        report: Report = self._report_repository.find_report_by_id(report_id)
+        report.state = 'INVALID'
+        self._report_repository.save_report(report)
+
     def _get_report_info_object(self, game_team_ids: list[int], reports_or_cheer_talks: List[Union[CheerTalk, Report]], user_data: Member):
         game_team_objects = self._game_repository.find_game_team_with_game_league_and_sport_by_ids(game_team_ids, user_data)
         game_team_dict = {game_team.id: game_team for game_team in game_team_objects}

--- a/src/sportslive/report/application/report_service.py
+++ b/src/sportslive/report/application/report_service.py
@@ -22,15 +22,20 @@ class ReportService:
         response_dto = self._ResponseDto(pending_report_infos, blocked_cheer_talks_infos)
         return ReportResponseSerializer(response_dto).data
     
-    def block_cheer_talk(self, cheer_talk_id: int):
-        cheer_talk: CheerTalk = self._cheer_talk_repository.find_cheer_talk_by_id(cheer_talk_id)
+    def block_cheer_talk(self, report_id: int):
+        report: Report = self._report_repository.find_report_by_id(report_id)
+        cheer_talk: CheerTalk = self._cheer_talk_repository.find_cheer_talk_by_id(report.cheer_talk_id)
 
-        if cheer_talk.is_bool_blocked == False:
+        if report.state == "PENDING":
             cheer_talk.is_blocked = True
-        elif cheer_talk.is_bool_blocked == True:
+            report.state = "VALID"
+        elif report.state == "VALID":
             cheer_talk.is_blocked = False
-        self._cheer_talk_repository.save_cheer_talk(cheer_talk)
+            report.state = "PENDING"
 
+        self._report_repository.save_report(report)
+        self._cheer_talk_repository.save_cheer_talk(cheer_talk)
+        
     def make_report_invalid(self, report_id: int):
         report: Report = self._report_repository.find_report_by_id(report_id)
         report.state = 'INVALID'

--- a/src/sportslive/report/domain/report_repository.py
+++ b/src/sportslive/report/domain/report_repository.py
@@ -1,6 +1,12 @@
-from django.shortcuts import get_list_or_404
+from django.shortcuts import get_list_or_404, get_object_or_404
 from report.domain import Report
 
 class ReportRepository:
     def find_pending_reports_with_cheer_talk(self):
         return get_list_or_404(Report.objects.select_related('cheer_talk').order_by('-reported_at'), state='PENDING')
+    
+    def find_report_by_id(self, report_id: int):
+        return get_object_or_404(Report, id=report_id)
+    
+    def save_report(self, report: Report):
+        report.save()

--- a/src/sportslive/report/presentation/__init__.py
+++ b/src/sportslive/report/presentation/__init__.py
@@ -1,2 +1,3 @@
 from .report_view import ReportView
 from .block_cheertalk_view import BlockCheerTalkView
+from .invalid_report_view import InvalidReportView

--- a/src/sportslive/report/presentation/block_cheertalk_view.py
+++ b/src/sportslive/report/presentation/block_cheertalk_view.py
@@ -15,9 +15,9 @@ class BlockCheerTalkView(APIView):
         self._report_service = ReportContainer.report_service()
 
     @swagger_auto_schema(responses={"200": ""})
-    def post(self, request, cheer_talk_id: int):
+    def post(self, request, report_id: int):
         """
-        응원톡 블럭 API
+        PENDING 상태인 report를 VALID로 만들고 응원톡을 블럭하거나, VALID인 report를 PENDING으로 만들고 응원톡을 블럭 취소하는 API
         """
-        response = self._report_service.block_cheer_talk(cheer_talk_id)
+        response = self._report_service.block_cheer_talk(report_id)
         return Response(response, status=status.HTTP_200_OK)

--- a/src/sportslive/report/presentation/invalid_report_view.py
+++ b/src/sportslive/report/presentation/invalid_report_view.py
@@ -1,0 +1,23 @@
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from accounts.domain import IsAdminUser
+from report.containers import ReportContainer
+from drf_yasg.utils import swagger_auto_schema
+
+class InvalidReportView(APIView):
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAdminUser]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._report_service = ReportContainer.report_service()
+
+    @swagger_auto_schema(responses={"200": ""})
+    def post(self, request, report_id: int):
+        """
+        상태가 PENDING 신고 중에서 허위 신고를 Invalid 상태로 변경시키는 api
+        """
+        response = self._report_service.make_report_invalid(report_id)
+        return Response(response, status=status.HTTP_200_OK)

--- a/src/sportslive/report/urls.py
+++ b/src/sportslive/report/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from report.presentation import ReportView, BlockCheerTalkView
+from report.presentation import ReportView, BlockCheerTalkView, InvalidReportView
 
 app_name = 'report'
 
 urlpatterns = [
     path('', ReportView.as_view()),
-    path('cheer-talk/<int:cheer_talk_id>/', BlockCheerTalkView.as_view())
+    path('cheer-talk/<int:cheer_talk_id>/', BlockCheerTalkView.as_view()),
+    path('invalid/<int:report_id>/', InvalidReportView.as_view()),
 ]

--- a/src/sportslive/report/urls.py
+++ b/src/sportslive/report/urls.py
@@ -5,6 +5,6 @@ app_name = 'report'
 
 urlpatterns = [
     path('', ReportView.as_view()),
-    path('cheer-talk/<int:cheer_talk_id>/', BlockCheerTalkView.as_view()),
+    path('cheer-talk/<int:report_id>/', BlockCheerTalkView.as_view()),
     path('invalid/<int:report_id>/', InvalidReportView.as_view()),
 ]

--- a/src/tests/resources/fixture.sql
+++ b/src/tests/resources/fixture.sql
@@ -94,4 +94,5 @@ VALUES  (3, '2023-11-11 00:00:00', '이미 신고된 댓글이야', false, 1),
 
 INSERT INTO reports (id, cheer_talk_id, reported_at, state)
 VALUES  (1, 3, '2023-11-11 00:00:00', 'UNCHECKED'),
-        (2, 4, '2023-11-13 00:00:00', 'PENDING');
+        (2, 4, '2023-11-13 00:00:00', 'PENDING'),
+        (3, 2, '2023-11-13 00:00:00', 'VALID');

--- a/src/tests/test_report.py
+++ b/src/tests/test_report.py
@@ -29,9 +29,12 @@ class TestReport:
     @pytest.mark.django_db
     def test_block_cheer_talk(self, load_sql_fixture, dependency_fixture):
         member = Member.objects.get(id=1)
-        self._report_service.block_cheer_talk(1)
         self._report_service.block_cheer_talk(2)
-        assert CheerTalk.objects.get(id=1).is_blocked == True
+        self._report_service.block_cheer_talk(3)
+        assert Report.objects.get(id=2).state == "VALID"
+        assert CheerTalk.objects.get(id=4).is_blocked == True
+        assert Report.objects.get(id=3).state == "PENDING"
+        assert CheerTalk.objects.get(id=2).is_blocked == False
 
     @pytest.mark.django_db
     def test_invalid_report(self, load_sql_fixture, dependency_fixture):

--- a/src/tests/test_report.py
+++ b/src/tests/test_report.py
@@ -32,3 +32,8 @@ class TestReport:
         self._report_service.block_cheer_talk(1)
         self._report_service.block_cheer_talk(2)
         assert CheerTalk.objects.get(id=1).is_blocked == True
+
+    @pytest.mark.django_db
+    def test_invalid_report(self, load_sql_fixture, dependency_fixture):
+        self._report_service.make_report_invalid(2)
+        assert Report.objects.get(id=2).state == 'INVALID'


### PR DESCRIPTION
### 추가 api
https://backoffice.hufstreaming.site/reports/invalid/{report_id}/
- `PENDING` 상태인 report 중에서 허위 신고(욕설이나 비꼼이 없는 report)를 `INVALID`로 변경시켜줍니다.
### 변경 api
https://backoffice.hufstreaming.site/reports/cheer-talk/{report_id}/
- 기존 api url에서 cheer-talk-id를 넣는 것이 아니라, report의 id를 넣습니다.
- `PENDING` 상태인 report중에 비꼼이나 교묘하게 피한 욕설이 들어있는 응원톡을 `VALID`로 만들고 응원톡을 블럭(is_blocked = True)
- `VALID`인 report를 `PENDING`으로 만들고 응원톡을 블럭 취소(is_valid = False)하여 원복 시키는 api로 변경