### PR TITLE
[REFACTOR] 리그팀 없을 시 404가 아닌 빈 리스트 반환

### DIFF
--- a/src/sportslive/team/domain/team_repository.py
+++ b/src/sportslive/team/domain/team_repository.py
@@ -6,7 +6,7 @@ class TeamRepository:
         team.save()
 
     def find_all_teams_by_league_id(self, league_id: int):
-        return get_list_or_404(LeagueTeam, league_id=league_id)
+        return LeagueTeam.objects.filter(league_id=league_id)
     
     def find_team_by_id(self, team_id: int):
         return get_object_or_404(LeagueTeam, id=team_id)


### PR DESCRIPTION
### 작업한 내용
- `/league-teams/{league_id}/` 호출시 리그가 없어도 404, 리그가 있어도 리그 팀이 없을 때 404 에러 반환
- 헷갈리기 때문에 리그 팀이 없을 때`404`에서 `[]`로 전송
