### PR TITLE
[FEAT] manger 화면 메인 get list 기능 추가

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -379,6 +379,20 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "freezegun"
+version = "1.4.0"
+description = "Let your Python tests travel through time"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "freezegun-1.4.0-py3-none-any.whl", hash = "sha256:55e0fc3c84ebf0a96a5aa23ff8b53d70246479e9a68863f1fcac5a3e52f19dd6"},
+    {file = "freezegun-1.4.0.tar.gz", hash = "sha256:10939b0ba0ff5adaecf3b06a5c2f73071d9678e507c5eaedb23c761d56ac774b"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "gunicorn"
 version = "21.2.0"
 description = "WSGI HTTP Server for UNIX"
@@ -848,4 +862,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "c2da8e27e03bfd06e34cfeca0146fcd1489a2a26c2fc519389d6eee19978daca"
+content-hash = "91960d9c8a35f39af107a52c40e422e02812b711b0e81966c26c2de375a8e43a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pillow = "^10.1.0"
 drf-yasg = "^1.21.7"
 pytest = "^8.0.1"
 pytest-django = "^4.8.0"
+freezegun = "^1.4.0"
 
 
 [build-system]

--- a/src/sportslive/game/domain/game.py
+++ b/src/sportslive/game/domain/game.py
@@ -12,7 +12,7 @@ class Game(models.Model):
     id = models.BigAutoField(primary_key=True)
     sport = models.ForeignKey(Sport, models.DO_NOTHING)
     manager = models.ForeignKey(Member, models.DO_NOTHING)
-    league = models.ForeignKey(League, models.DO_NOTHING)
+    league = models.ForeignKey(League, models.DO_NOTHING, related_name='league_games')
     name = models.CharField(max_length=255)
     start_time = models.DateTimeField()
     video_id = models.CharField(max_length=255, blank=True, null=True)

--- a/src/sportslive/league/application/league_get_service.py
+++ b/src/sportslive/league/application/league_get_service.py
@@ -1,5 +1,5 @@
 from league.domain import LeagueRepository
-from league.serializers import LeagueListGetSerializer
+from league.serializers import LeagueListGetSerializer, MainListGetSerializer
 from league.domain import League, LeagueSport
 from datetime import datetime
 import pytz
@@ -15,6 +15,21 @@ class LeagueGetService:
         league_get_serializer = LeagueListGetSerializer(self._ListWrapping(result_dict))
         return league_get_serializer.data
     
+    def get_main(self, user_data):
+        organization_id: int = user_data.organization_id
+        leagues: list[League] = self._league_repository.find_all_leagues_with_games_by_organization_id(organization_id)
+        playing_leagues = []
+        for league in leagues:
+            result = self._classify_league(league)
+            if result == 'playing':
+                playing_leagues.append(league)
+
+        for playing_league in playing_leagues:
+            playing_league.playing_game_datas = playing_league.league_games.all()
+
+        main_list_get_serialzier = MainListGetSerializer(playing_leagues, many=True)
+        return main_list_get_serialzier.data
+
     def _classify_league_and_add_sport_data(self, leagues: list[League]):
         result_dict = {
             "playing": [],

--- a/src/sportslive/league/domain/league_repository.py
+++ b/src/sportslive/league/domain/league_repository.py
@@ -29,3 +29,19 @@ class LeagueRepository:
         ).prefetch_related(
             league_sport_prefetch
         ).order_by('-start_at')
+    
+    def find_all_leagues_by_organization_id(self, organization_id: int):
+        return League.objects.filter(organization_id=organization_id)
+    
+    def find_all_leagues_with_games_by_organization_id(self, organization_id: int):
+        from game.domain import Game
+        league_games_prefetch = Prefetch(
+            'league_games',
+            queryset=Game.objects.filter(state='PLAYING')
+        )
+        return League.objects.filter(
+            organization_id=organization_id,
+            is_deleted=False
+        ).prefetch_related(
+            league_games_prefetch
+        ).order_by('-start_at')

--- a/src/sportslive/league/presentation/__init__.py
+++ b/src/sportslive/league/presentation/__init__.py
@@ -1,2 +1,3 @@
 from .league_view import LeagueView
 from .league_get_view import LeagueGetView
+from .main_get_view import MainGetView

--- a/src/sportslive/league/presentation/main_get_view.py
+++ b/src/sportslive/league/presentation/main_get_view.py
@@ -1,0 +1,24 @@
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from accounts.domain import IsAdminUser
+from league.containers import LeagueContainer
+from drf_yasg.utils import swagger_auto_schema
+from league.serializers import MainListGetSerializer
+
+class MainGetView(APIView):
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAdminUser]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._league_get_service = LeagueContainer.league_get_service()
+
+    @swagger_auto_schema(responses={"200": MainListGetSerializer(many=True)})
+    def get(self, request):
+        """
+        매니저 서버 메인 조회 API
+        """
+        response = self._league_get_service.get_main(request.user)
+        return Response(response, status.HTTP_200_OK)

--- a/src/sportslive/league/serializers/__init__.py
+++ b/src/sportslive/league/serializers/__init__.py
@@ -5,3 +5,4 @@ from .league_serializer import (
                     LeagueRegisterResponseSerializer,
                 )
 from .league_get_serializer import LeagueListGetSerializer
+from .main_serializer import MainListGetSerializer

--- a/src/sportslive/league/serializers/main_serializer.py
+++ b/src/sportslive/league/serializers/main_serializer.py
@@ -10,8 +10,9 @@ class _MainGameInfoSerializer(serializers.ModelSerializer):
         fields = ('id', 'startTime', 'name', 'round',)
 
 class MainListGetSerializer(serializers.ModelSerializer):
+    leagueName = serializers.CharField(source='name')
     playingGameData = _MainGameInfoSerializer(many=True, source='playing_game_datas')
 
     class Meta:
         model = League
-        fields = ('name', 'playingGameData',)
+        fields = ('leagueName', 'playingGameData',)

--- a/src/sportslive/league/serializers/main_serializer.py
+++ b/src/sportslive/league/serializers/main_serializer.py
@@ -1,0 +1,17 @@
+from rest_framework import serializers
+from league.domain import League
+from game.domain import Game
+
+class _MainGameInfoSerializer(serializers.ModelSerializer):
+    startTime = serializers.DateTimeField(source='start_time')
+
+    class Meta:
+        model = Game
+        fields = ('id', 'startTime', 'name', 'round',)
+
+class MainListGetSerializer(serializers.ModelSerializer):
+    playingGameData = _MainGameInfoSerializer(many=True, source='playing_game_datas')
+
+    class Meta:
+        model = League
+        fields = ('name', 'playingGameData',)

--- a/src/sportslive/sports_live/urls.py
+++ b/src/sportslive/sports_live/urls.py
@@ -6,6 +6,7 @@ from rest_framework import routers
 from rest_framework import permissions
 from django.urls import include, path, re_path
 from django.conf import settings
+from league.presentation import MainGetView
 
 router = routers.DefaultRouter()
 
@@ -23,6 +24,7 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
+    path('main/', MainGetView.as_view()),
     path('admin/', admin.site.urls),
     path('accounts/', include("accounts.urls")),
     path('games/', include("game.urls")),

--- a/src/tests/test_league_get.py
+++ b/src/tests/test_league_get.py
@@ -4,6 +4,7 @@ from .fixture import load_sql_fixture
 from league.containers import LeagueContainer
 from league.domain import LeagueSport, League
 from django.core.exceptions import PermissionDenied
+from freezegun import freeze_time
 
 class TestLeagueGet:
 
@@ -12,9 +13,17 @@ class TestLeagueGet:
         self._league_get_service = LeagueContainer.league_get_service()
 
     @pytest.mark.django_db
+    @freeze_time("2024-03-18")
     def test_get_league_list(self, load_sql_fixture, dependency_fixture):
         member = Member.objects.get(id=1)
         response = self._league_get_service.get_leagues(member)
         assert len(response['scheduled']) == 2
+
+    @pytest.mark.django_db
+    @freeze_time("2024-03-21")
+    def test_get_main_list(self, load_sql_fixture, dependency_fixture):
+        member = Member.objects.get(id=1)
+        response = self._league_get_service.get_main(member)
+        assert len(response[0].get("playingGameData")) == 1
         
         


### PR DESCRIPTION
### 작업한 내용
- /main/ 경로의 `get` 추가
- 현재 진행 중인 리그의 진행 중인 게임만 보여주는 get api
```json
[
  {
    "leagueName": "string",
    "playingGameData": [
      {
        "id": 0,
        "startTime": "2019-08-24T14:15:22Z",
        "name": "string",
        "round": 0
      }
    ]
  }
]
```  
