### PR TITLE
[REFACTOR/FEAT] record 상세 조회 추가 및 record_type 대문자 변경

### DIFF
--- a/src/sportslive/game/serializers/__init__.py
+++ b/src/sportslive/game/serializers/__init__.py
@@ -12,4 +12,9 @@ from .game_team_serializer import (
                             LineupPlayerChangeSerialzier,
                             GameScoreChangeSerializer
                             )
-from .game_team_get_serializer import LineupPlayerGetSerializer, GameTeamInfoSerializer
+from .game_team_get_serializer import (
+        LineupPlayerGetSerializer,
+        GameTeamInfoSerializer,
+        GameTeamNameInfoSerializer,
+        LineupPlayerNameNumberGetSerializer
+    )

--- a/src/sportslive/game/serializers/game_team_get_serializer.py
+++ b/src/sportslive/game/serializers/game_team_get_serializer.py
@@ -8,6 +8,12 @@ class LineupPlayerGetSerializer(serializers.ModelSerializer):
         model = LineupPlayer
         fields = ('id', 'name', 'description', 'number', 'isCaptain')
 
+class LineupPlayerNameNumberGetSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = LineupPlayer
+        fields = ('id', 'name', 'number')
+
 class GameTeamInfoSerializer(serializers.ModelSerializer):
     gameTeamId = serializers.IntegerField(source='id')
     gameTeamName = serializers.CharField(source='league_team.name')
@@ -17,3 +23,11 @@ class GameTeamInfoSerializer(serializers.ModelSerializer):
     class Meta:
         model = GameTeam
         fields = ('gameTeamId', 'gameTeamName', 'logoImageUrl', 'score')
+
+class GameTeamNameInfoSerializer(serializers.ModelSerializer):
+    gameTeamId = serializers.IntegerField(source='id')
+    gameTeamName = serializers.CharField(source='league_team.name')
+    
+    class Meta:
+        model = GameTeam
+        fields = ('gameTeamId', 'gameTeamName')

--- a/src/sportslive/record/application/__init__.py
+++ b/src/sportslive/record/application/__init__.py
@@ -1,2 +1,3 @@
 from .record_create_service import RecordCreateService
 from .record_service import RecordService
+from .record_get_service import RecordGetService

--- a/src/sportslive/record/application/record_create_service.py
+++ b/src/sportslive/record/application/record_create_service.py
@@ -35,7 +35,8 @@ class RecordCreateService:
         datetime_recorded_at = record_data.get('recorded_at')
         int_recorded_at = self._make_integer_recorded_at(datetime_recorded_at, game)
         recorded_quarter_id = record_data.get('recorded_quarter_id')
-        new_record: Record = self._create_new_record_object(game_id, game_team, recorded_quarter_id, record_type, int_recorded_at)
+        record_type_upper = record_type.upper()
+        new_record: Record = self._create_new_record_object(game_id, game_team, recorded_quarter_id, record_type_upper, int_recorded_at)
         self._record_repository.save_record(new_record)
         return new_record
     

--- a/src/sportslive/record/application/record_get_service.py
+++ b/src/sportslive/record/application/record_get_service.py
@@ -10,12 +10,12 @@ class RecordGetService:
 
     def get_record_detail(self, record_id: int):
         record: Record = self._record_repository.find_record_by_id(record_id)
-        if record.record_type == 'score':
+        if record.record_type == 'SCORE':
             score_record: ScoreRecord = self._record_repository.find_score_record_by_record_id_with_record_quarter_and_league_team(record_id)
             score_record.record_info = record
             return ScoreRecordResponseSerializer(score_record).data
         
-        elif record.record_type == 'replacement':
+        elif record.record_type == 'REPLACEMENT':
             replacement_record: ReplacementRecord = self._record_repository.find_replacement_record_by_record_id_with_record_quarter_and_league_team(record_id)
             replacement_record.record_info = record
             return ReplacementRecordResponseSerializer(replacement_record).data

--- a/src/sportslive/record/application/record_get_service.py
+++ b/src/sportslive/record/application/record_get_service.py
@@ -1,0 +1,23 @@
+from record.domain import RecordRepository, Record, ScoreRecord, ReplacementRecord
+from record.serializers import ScoreRecordResponseSerializer, ReplacementRecordResponseSerializer
+from game.domain import GameRepository
+from utils.exceptions.record_exception import NotValidRecordTypeError
+
+class RecordGetService:
+    def __init__(self, record_repository: RecordRepository, game_repository: GameRepository):
+        self._record_repository = record_repository
+        self._game_repository = game_repository
+
+    def get_record_detail(self, record_id: int):
+        record: Record = self._record_repository.find_record_by_id(record_id)
+        if record.record_type == 'score':
+            score_record: ScoreRecord = self._record_repository.find_score_record_by_record_id_with_record_quarter_and_league_team(record_id)
+            score_record.record_info = record
+            return ScoreRecordResponseSerializer(score_record).data
+        
+        elif record.record_type == 'replacement':
+            replacement_record: ReplacementRecord = self._record_repository.find_replacement_record_by_record_id_with_record_quarter_and_league_team(record_id)
+            replacement_record.record_info = record
+            return ReplacementRecordResponseSerializer(replacement_record).data
+        else:
+            raise NotValidRecordTypeError

--- a/src/sportslive/record/containers.py
+++ b/src/sportslive/record/containers.py
@@ -1,6 +1,6 @@
 from dependency_injector import containers, providers
 from record.domain import RecordRepository
-from record.application import RecordCreateService, RecordService
+from record.application import RecordCreateService, RecordService, RecordGetService
 from game.domain import GameRepository
 
 class RecordContainer(containers.DeclarativeContainer):
@@ -13,6 +13,11 @@ class RecordContainer(containers.DeclarativeContainer):
     )
     record_service = providers.Factory(
         RecordService,
+        record_repository=record_repository,
+        game_repository=game_repository,
+    )
+    record_get_service = providers.Factory(
+        RecordGetService,
         record_repository=record_repository,
         game_repository=game_repository,
     )

--- a/src/sportslive/record/domain/record_repository.py
+++ b/src/sportslive/record/domain/record_repository.py
@@ -20,3 +20,15 @@ class RecordRepository:
     
     def delete_record(self, record: Union[Record, ReplacementRecord, ScoreRecord]):
         return record.delete()
+    
+    def find_score_record_by_record_id_with_record_quarter_and_league_team(self, record_id: int):
+        return get_object_or_404(
+            ScoreRecord.objects.select_related('record', 'record__recorded_quarter', 'record__game_team__league_team'),
+            record_id=record_id
+        )
+    
+    def find_replacement_record_by_record_id_with_record_quarter_and_league_team(self, record_id: int):
+        return get_object_or_404(
+            ReplacementRecord.objects.select_related('record', 'record__recorded_quarter', 'record__game_team__league_team'),
+            record_id=record_id
+        )

--- a/src/sportslive/record/presentation/__init__.py
+++ b/src/sportslive/record/presentation/__init__.py
@@ -1,3 +1,4 @@
 from .record_create_view import RecordCreateView
 from .record_change_view import RecordChangeView
 from .record_delete_view import RecordDeleteView
+from .record_get_view import RecordGetView

--- a/src/sportslive/record/presentation/record_get_view.py
+++ b/src/sportslive/record/presentation/record_get_view.py
@@ -1,0 +1,20 @@
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from accounts.domain import IsAdminUser
+from record.containers import RecordContainer
+from drf_yasg.utils import swagger_auto_schema
+
+class RecordGetView(APIView):
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAdminUser]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._record_get_service = RecordContainer.record_get_service()
+
+    @swagger_auto_schema(responses={"200": ""})
+    def get(self, request, record_id: int, record_type: str):
+        response = self._record_get_service.get_record_detail(record_id)
+        return Response(response, status=status.HTTP_200_OK)

--- a/src/sportslive/record/serializers/__init__.py
+++ b/src/sportslive/record/serializers/__init__.py
@@ -4,3 +4,7 @@ from .record_serializer import (
     ScoreRecordChangeRequestSerializer,
     ReplacementRecordChangeRequestSerializer,
 )
+from .record_get_serializer import (
+    ReplacementRecordResponseSerializer,
+    ScoreRecordResponseSerializer
+)

--- a/src/sportslive/record/serializers/record_get_serializer.py
+++ b/src/sportslive/record/serializers/record_get_serializer.py
@@ -1,0 +1,31 @@
+from rest_framework import serializers
+from record.domain import ScoreRecord, ReplacementRecord, Record
+from sport.serializers import SportsQuarterResponseSerializer
+from game.serializers import GameTeamNameInfoSerializer, LineupPlayerNameNumberGetSerializer
+
+class _RecordResponseSerialzier(serializers.ModelSerializer):
+    gameTeam = GameTeamNameInfoSerializer(source='game_team')
+    recordedQuarter = SportsQuarterResponseSerializer(source='recorded_quarter')
+    recordedAt = serializers.IntegerField(source='recorded_at')
+    recordType = serializers.CharField(source='record_type')
+
+    class Meta:
+        model = Record
+        fields = ('game', 'gameTeam', 'recordedQuarter', 'recordedAt', 'recordType')
+
+class ScoreRecordResponseSerializer(serializers.ModelSerializer):
+    recordInfo = _RecordResponseSerialzier(source='record_info')
+    lineupPlayer = LineupPlayerNameNumberGetSerializer(source='lineup_player')
+
+    class Meta:
+        model = ScoreRecord
+        fields = ('recordInfo', 'lineupPlayer', 'score')
+
+class ReplacementRecordResponseSerializer(serializers.ModelSerializer):
+    recordInfo = _RecordResponseSerialzier(source='record_info')
+    originLineupPlayer = LineupPlayerNameNumberGetSerializer(source='origin_lineup_player')
+    replacedLineupPlayer = LineupPlayerNameNumberGetSerializer(source='replaced_lineup_player')
+
+    class Meta:
+        model = ReplacementRecord
+        fields = ('recordInfo', 'originLineupPlayer', 'replacedLineupPlayer')

--- a/src/sportslive/record/urls.py
+++ b/src/sportslive/record/urls.py
@@ -11,6 +11,6 @@ app_name = 'record'
 urlpatterns = [
     path('<int:record_id>/', RecordGetView.as_view()),
     path('create/<str:record_type>/<int:game_id>/', RecordCreateView.as_view()),
-    path('change/<int:record_id>/<str:record_type>/', RecordChangeView.as_view()),
-    path('delete/<int:record_id>/<str:record_type>/', RecordDeleteView.as_view()),
+    path('change/<int:record_id>/', RecordChangeView.as_view()),
+    path('delete/<int:record_id>/', RecordDeleteView.as_view()),
 ]

--- a/src/sportslive/record/urls.py
+++ b/src/sportslive/record/urls.py
@@ -3,11 +3,13 @@ from record.presentation import (
     RecordCreateView,
     RecordChangeView,
     RecordDeleteView,
+    RecordGetView
 )
 
 app_name = 'record'
 
 urlpatterns = [
+    path('<int:record_id>/', RecordGetView.as_view()),
     path('create/<str:record_type>/<int:game_id>/', RecordCreateView.as_view()),
     path('change/<int:record_id>/<str:record_type>/', RecordChangeView.as_view()),
     path('delete/<int:record_id>/<str:record_type>/', RecordDeleteView.as_view()),

--- a/src/tests/resources/fixture.sql
+++ b/src/tests/resources/fixture.sql
@@ -71,9 +71,9 @@ VALUES  (1, 1, '미컴선수1', NULL, 11, 0),
         (12, 6, '인도선수2', NULL, 44, 1);
 
 INSERT INTO records (id, record_type, game_id, game_team_id, recorded_quarter_id, recorded_at)
-VALUES  (1, 'score', 3, 5, 1, 31),
-        (2, 'score', 3, 5, 1, 44),
-        (3, 'replacement', 3, 6, 2, 3);
+VALUES  (1, 'SCORE', 3, 5, 1, 31),
+        (2, 'SCORE', 3, 5, 1, 44),
+        (3, 'REPLACEMENT', 3, 6, 2, 3);
 
 INSERT INTO score_records (id, score, lineup_player_id, record_id)
 VALUES (1, 1, 9, 1),

--- a/src/tests/test_record.py
+++ b/src/tests/test_record.py
@@ -63,7 +63,7 @@ class TestRecord:
             "scoreLineupPlayerId": 9,
             "score": 1
         }
-        self._record_service.change_record(1, 'score', request_data)
+        self._record_service.change_record(1, request_data)
 
         assert Record.objects.get(id=1).recorded_at == 2
         assert Record.objects.get(id=1).recorded_quarter_id == 2
@@ -81,7 +81,7 @@ class TestRecord:
             "scoreLineupPlayerId": 10,
             "score": 2
         }
-        self._record_service.change_record(1, 'score', request_data)
+        self._record_service.change_record(1, request_data)
 
         assert Record.objects.get(id=1).recorded_at == 2
         assert Record.objects.get(id=1).recorded_quarter_id == 2
@@ -101,7 +101,7 @@ class TestRecord:
             "recordedQuarterId": 2,
             "replacedLineupPlayerId": 11
         }
-        self._record_service.change_record(3, 'replacement', request_data)
+        self._record_service.change_record(3, request_data)
 
         assert ReplacementRecord.objects.get(id=1).origin_lineup_player_id == 12
         assert ReplacementRecord.objects.get(id=1).replaced_lineup_player_id == 11
@@ -111,8 +111,8 @@ class TestRecord:
         """
         score 타임라인 하나를 삭제한다
         """
-        self._record_service.delete_record(1, 'score')
-        self._record_service.delete_record(2, 'score')
+        self._record_service.delete_record(1)
+        self._record_service.delete_record(2)
 
         assert Record.objects.filter(id=1).exists() == False
         assert ScoreRecord.objects.filter(id=1).exists() == False

--- a/src/tests/test_record_get.py
+++ b/src/tests/test_record_get.py
@@ -1,0 +1,34 @@
+import pytest
+from accounts.domain.member import Member
+from .fixture import load_sql_fixture
+from record.containers import RecordContainer
+from record.domain import Record, ScoreRecord, ReplacementRecord
+from game.domain import GameTeam
+from utils.exceptions.record_exception import NotValidRecordTypeError
+
+class TestRecord:
+
+    @pytest.fixture
+    def dependency_fixture(self):
+        self._record_get_service = RecordContainer.record_get_service()
+
+    @pytest.mark.django_db
+    def test_get_record(self, load_sql_fixture, dependency_fixture):
+        result = self._record_get_service.get_record_detail(3)
+
+        assert result["recordInfo"]["game"] == 3
+        assert result["recordInfo"]["gameTeam"]["gameTeamId"] == 6
+        assert result["recordInfo"]["gameTeam"]["gameTeamName"] == "인도어과"
+        assert result["recordInfo"]["recordedQuarter"]["id"] == 2
+        assert result["recordInfo"]["recordedQuarter"]["name"] == "후반전"
+        assert result["recordInfo"]["recordedAt"] == 3
+        assert result["recordInfo"]["recordType"] == "REPLACEMENT"
+
+        assert result["originLineupPlayer"]["id"] == 11
+        assert result["originLineupPlayer"]["name"] == "인도선수1"
+        assert result["originLineupPlayer"]["number"] == 22
+
+        assert result["replacedLineupPlayer"]["id"] == 12
+        assert result["replacedLineupPlayer"]["name"] == "인도선수2"
+        assert result["replacedLineupPlayer"]["number"] == 44
+       


### PR DESCRIPTION
## 작업한 내용
### 타임라인 상세조회 관련
- /timelines/{record_id}/ 로 타임라인 상세조회
- 교체 타임라인일 경우
```json
{
    "recordInfo": {
        "game": 3,
        "gameTeam": {
            "gameTeamId": 6,
            "gameTeamName": "인도어과"
        },
        "recordedQuarter": {
            "id": 2,
            "name": "후반전"
        },
        "recordedAt": 3,
        "recordType": "replacement"
    },
    "originLineupPlayer": {
        "id": 11,
        "name": "인도선수1",
        "number": 22
    },
    "replacedLineupPlayer": {
        "id": 12,
        "name": "인도선수2",
        "number": 44
    }
}
```
- 점수 타임라인일 경우
```json
{
    "recordInfo": {
        "game": 3,
        "gameTeam": {
            "gameTeamId": 5,
            "gameTeamName": "미컴과"
        },
        "recordedQuarter": {
            "id": 1,
            "name": "전반전"
        },
        "recordedAt": 31,
        "recordType": "SCORE"
    },
    "lineupPlayer": {
        "id": 9,
        "name": "미컴선수1",
        "number": 11
    },
    "score": 1
}
```
### record_type 대문자 변경 관련
- 혼동을 막기위해 change와 delete api 모두 record_type을 url 파라미터로 받는 것을 삭제
- 각 `change/<int:record_id>/` 와 `delete/<int:record_id>/`로 변경

