### PR TITLE
[REFACTOR] report 분리 및 block api 추가

### DIFF
--- a/src/sportslive/report/application/__init__.py
+++ b/src/sportslive/report/application/__init__.py
@@ -1,1 +1,2 @@
 from .report_service import ReportService
+from .report_get_service import ReportGetService

--- a/src/sportslive/report/application/report_get_service.py
+++ b/src/sportslive/report/application/report_get_service.py
@@ -1,0 +1,44 @@
+from report.domain import ReportRepository, CheerTalkRepository, Report, CheerTalk
+from report.serializers import ReportResponseSerializer
+from game.domain import GameRepository, GameTeam
+from accounts.domain import Member
+from typing import List, Union
+
+class ReportGetService:
+    def __init__(self, report_repository: ReportRepository, cheer_talk_repository: CheerTalkRepository, game_repository: GameRepository):
+        self._report_repository = report_repository
+        self._cheer_talk_repository = cheer_talk_repository
+        self._game_repository = game_repository
+
+    def get_report_info(self, user_data: Member):
+        pending_reports: list[Report] = self._report_repository.find_pending_reports_with_cheer_talk()
+        game_team_ids: list[int] = [report.cheer_talk.game_team_id for report in pending_reports]
+        pending_report_infos = self._get_report_info_object(game_team_ids, pending_reports, user_data)
+
+        blocked_cheer_talks: list[CheerTalk] = self._cheer_talk_repository.find_is_blocked_cheer_talks()
+        game_team_ids: list[int] = [cheer_talk.game_team_id for cheer_talk in blocked_cheer_talks]
+        blocked_cheer_talks_infos = self._get_report_info_object(game_team_ids, blocked_cheer_talks, user_data)
+
+        response_dto = self._ResponseDto(pending_report_infos, blocked_cheer_talks_infos)
+        return ReportResponseSerializer(response_dto).data
+
+
+    def _get_report_info_object(self, game_team_ids: list[int], reports_or_cheer_talks: List[Union[CheerTalk, Report]], user_data: Member):
+        game_team_objects = self._game_repository.find_game_team_with_game_league_and_sport_by_ids(game_team_ids, user_data)
+        game_team_dict = {game_team.id: game_team for game_team in game_team_objects}
+        game_team_infos = [game_team_dict.get(game_team_id, None) for game_team_id in game_team_ids]
+        return [
+                self._ReportOrCheerTalkInfo(report_or_cheer_talk, game_info)
+                for report_or_cheer_talk, game_info in zip(reports_or_cheer_talks, game_team_infos)
+                if game_info is not None
+            ]
+    
+    class _ResponseDto:
+        def __init__(self, pending: list, blocked_cheer_talks_infos: list):
+            self.pending = pending
+            self.blocked_cheer_talks_infos = blocked_cheer_talks_infos
+
+    class _ReportOrCheerTalkInfo:
+        def __init__(self, report_or_cheer_talk, game_info: GameTeam):
+            self.report_or_cheer_talk = report_or_cheer_talk
+            self.game_info = game_info

--- a/src/sportslive/report/application/report_service.py
+++ b/src/sportslive/report/application/report_service.py
@@ -1,12 +1,11 @@
 from report.domain import ReportRepository, CheerTalkRepository, Report, CheerTalk
-from game.domain import GameRepository
 
 class ReportService:
     def __init__(self, report_repository: ReportRepository, cheer_talk_repository: CheerTalkRepository):
         self._report_repository = report_repository
         self._cheer_talk_repository = cheer_talk_repository
     
-    def block_cheer_talk(self, report_id: int):
+    def manage_report_state_and_cheer_talk_state(self, report_id: int):
         report: Report = self._report_repository.find_report_by_id(report_id)
         cheer_talk: CheerTalk = self._cheer_talk_repository.find_cheer_talk_by_id(report.cheer_talk_id)
 

--- a/src/sportslive/report/application/report_service.py
+++ b/src/sportslive/report/application/report_service.py
@@ -1,26 +1,10 @@
 from report.domain import ReportRepository, CheerTalkRepository, Report, CheerTalk
-from report.serializers import ReportResponseSerializer
-from game.domain import GameRepository, GameTeam
-from accounts.domain import Member
-from typing import List, Union
+from game.domain import GameRepository
 
 class ReportService:
-    def __init__(self, report_repository: ReportRepository, cheer_talk_repository: CheerTalkRepository, game_repository: GameRepository):
+    def __init__(self, report_repository: ReportRepository, cheer_talk_repository: CheerTalkRepository):
         self._report_repository = report_repository
         self._cheer_talk_repository = cheer_talk_repository
-        self._game_repository = game_repository
-
-    def get_report_info(self, user_data: Member):
-        pending_reports: list[Report] = self._report_repository.find_pending_reports_with_cheer_talk()
-        game_team_ids: list[int] = [report.cheer_talk.game_team_id for report in pending_reports]
-        pending_report_infos = self._get_report_info_object(game_team_ids, pending_reports, user_data)
-
-        blocked_cheer_talks: list[CheerTalk] = self._cheer_talk_repository.find_is_blocked_cheer_talks()
-        game_team_ids: list[int] = [cheer_talk.game_team_id for cheer_talk in blocked_cheer_talks]
-        blocked_cheer_talks_infos = self._get_report_info_object(game_team_ids, blocked_cheer_talks, user_data)
-
-        response_dto = self._ResponseDto(pending_report_infos, blocked_cheer_talks_infos)
-        return ReportResponseSerializer(response_dto).data
     
     def block_cheer_talk(self, report_id: int):
         report: Report = self._report_repository.find_report_by_id(report_id)
@@ -40,23 +24,3 @@ class ReportService:
         report: Report = self._report_repository.find_report_by_id(report_id)
         report.state = 'INVALID'
         self._report_repository.save_report(report)
-
-    def _get_report_info_object(self, game_team_ids: list[int], reports_or_cheer_talks: List[Union[CheerTalk, Report]], user_data: Member):
-        game_team_objects = self._game_repository.find_game_team_with_game_league_and_sport_by_ids(game_team_ids, user_data)
-        game_team_dict = {game_team.id: game_team for game_team in game_team_objects}
-        game_team_infos = [game_team_dict.get(game_team_id, None) for game_team_id in game_team_ids]
-        return [
-                self._ReportOrCheerTalkInfo(report_or_cheer_talk, game_info)
-                for report_or_cheer_talk, game_info in zip(reports_or_cheer_talks, game_team_infos)
-                if game_info is not None
-            ]
-    
-    class _ResponseDto:
-        def __init__(self, pending: list, blocked_cheer_talks_infos: list):
-            self.pending = pending
-            self.blocked_cheer_talks_infos = blocked_cheer_talks_infos
-
-    class _ReportOrCheerTalkInfo:
-        def __init__(self, report_or_cheer_talk, game_info: GameTeam):
-            self.report_or_cheer_talk = report_or_cheer_talk
-            self.game_info = game_info

--- a/src/sportslive/report/application/report_service.py
+++ b/src/sportslive/report/application/report_service.py
@@ -18,7 +18,15 @@ class ReportService:
 
         self._report_repository.save_report(report)
         self._cheer_talk_repository.save_cheer_talk(cheer_talk)
-        
+    
+    def block_cheer_talk(self, cheer_talk_id: int):
+        cheer_talk: CheerTalk = self._cheer_talk_repository.find_cheer_talk_by_id(cheer_talk_id)
+        if cheer_talk.is_bool_blocked:
+            cheer_talk.is_blocked = False
+        else:
+            cheer_talk.is_blocked = True
+        self._cheer_talk_repository.save_cheer_talk(cheer_talk)
+
     def make_report_invalid(self, report_id: int):
         report: Report = self._report_repository.find_report_by_id(report_id)
         report.state = 'INVALID'

--- a/src/sportslive/report/containers.py
+++ b/src/sportslive/report/containers.py
@@ -1,7 +1,7 @@
 from dependency_injector import containers, providers
 from report.domain import ReportRepository, CheerTalkRepository
 from game.domain import GameRepository
-from report.application import ReportService
+from report.application import ReportService, ReportGetService
 
 class ReportContainer(containers.DeclarativeContainer):
     report_repository = providers.Factory(ReportRepository)
@@ -9,6 +9,11 @@ class ReportContainer(containers.DeclarativeContainer):
     game_repository = providers.Factory(GameRepository)
     report_service = providers.Factory(
         ReportService,
+        report_repository=report_repository,
+        cheer_talk_repository=cheer_talk_repository
+    )
+    report_get_service = providers.Factory(
+        ReportGetService,
         report_repository=report_repository,
         cheer_talk_repository=cheer_talk_repository,
         game_repository=game_repository,

--- a/src/sportslive/report/presentation/__init__.py
+++ b/src/sportslive/report/presentation/__init__.py
@@ -1,3 +1,4 @@
 from .report_list_view import ReportListView
 from .manage_report_view import ManageReportView
 from .invalid_report_view import InvalidReportView
+from .block_cheertalk_view import BlockCheerTalkView

--- a/src/sportslive/report/presentation/__init__.py
+++ b/src/sportslive/report/presentation/__init__.py
@@ -1,3 +1,3 @@
-from .report_view import ReportView
+from .report_list_view import ReportListView
 from .block_cheertalk_view import BlockCheerTalkView
 from .invalid_report_view import InvalidReportView

--- a/src/sportslive/report/presentation/__init__.py
+++ b/src/sportslive/report/presentation/__init__.py
@@ -1,3 +1,3 @@
 from .report_list_view import ReportListView
-from .block_cheertalk_view import BlockCheerTalkView
+from .manage_report_view import ManageReportView
 from .invalid_report_view import InvalidReportView

--- a/src/sportslive/report/presentation/block_cheertalk_view.py
+++ b/src/sportslive/report/presentation/block_cheertalk_view.py
@@ -15,9 +15,9 @@ class BlockCheerTalkView(APIView):
         self._report_service = ReportContainer.report_service()
 
     @swagger_auto_schema(responses={"200": ""})
-    def post(self, request, report_id: int):
+    def put(self, request, cheer_talk_id: int):
         """
-        PENDING 상태인 report를 VALID로 만들고 응원톡을 블럭하거나, VALID인 report를 PENDING으로 만들고 응원톡을 블럭 취소하는 API
+        cheertalk이 is_blocked가 True라면 False, False라면 True로 바꿔주는 api
         """
-        response = self._report_service.block_cheer_talk(report_id)
+        response = self._report_service.block_cheer_talk(cheer_talk_id)
         return Response(response, status=status.HTTP_200_OK)

--- a/src/sportslive/report/presentation/manage_report_view.py
+++ b/src/sportslive/report/presentation/manage_report_view.py
@@ -1,0 +1,23 @@
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from accounts.domain import IsAdminUser
+from report.containers import ReportContainer
+from drf_yasg.utils import swagger_auto_schema
+
+class ManageReportView(APIView):
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAdminUser]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._report_service = ReportContainer.report_service()
+
+    @swagger_auto_schema(responses={"200": ""})
+    def post(self, request, report_id: int):
+        """
+        PENDING 상태인 report를 VALID로 만들고 응원톡을 블럭하거나, VALID인 report를 PENDING으로 만들고 응원톡을 블럭 취소하는 API
+        """
+        response = self._report_service.manage_report_state_and_cheer_talk_state(report_id)
+        return Response(response, status=status.HTTP_200_OK)

--- a/src/sportslive/report/presentation/report_list_view.py
+++ b/src/sportslive/report/presentation/report_list_view.py
@@ -7,18 +7,18 @@ from report.containers import ReportContainer
 from drf_yasg.utils import swagger_auto_schema
 from report.serializers import ReportResponseSerializer
 
-class ReportView(APIView):
+class ReportListView(APIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAdminUser]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._report_service = ReportContainer.report_service()
+        self._report_get_service = ReportContainer.report_get_service()
 
     @swagger_auto_schema(responses={"200": ReportResponseSerializer})
     def get(self, request):
         """
         신고 조회 API
         """
-        response = self._report_service.get_report_info(request.user)
+        response = self._report_get_service.get_report_info(request.user)
         return Response(response, status=status.HTTP_200_OK)

--- a/src/sportslive/report/urls.py
+++ b/src/sportslive/report/urls.py
@@ -7,5 +7,5 @@ urlpatterns = [
     path('', ReportListView.as_view()),
     path('<int:report_id>/', ManageReportView.as_view()),
     path('invalid/<int:report_id>/', InvalidReportView.as_view()),
-    path('cheer-talks/<int:cheer_talk_id>/', BlockCheerTalkView.as_view()),
+    path('cheer-talk/<int:cheer_talk_id>/', BlockCheerTalkView.as_view()),
 ]

--- a/src/sportslive/report/urls.py
+++ b/src/sportslive/report/urls.py
@@ -1,10 +1,10 @@
 from django.urls import path
-from report.presentation import ReportListView, BlockCheerTalkView, InvalidReportView
+from report.presentation import ReportListView, ManageReportView, InvalidReportView
 
 app_name = 'report'
 
 urlpatterns = [
     path('', ReportListView.as_view()),
-    path('cheer-talk/<int:report_id>/', BlockCheerTalkView.as_view()),
+    path('<int:report_id>/', ManageReportView.as_view()),
     path('invalid/<int:report_id>/', InvalidReportView.as_view()),
 ]

--- a/src/sportslive/report/urls.py
+++ b/src/sportslive/report/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from report.presentation import ReportListView, ManageReportView, InvalidReportView
+from report.presentation import ReportListView, ManageReportView, InvalidReportView, BlockCheerTalkView
 
 app_name = 'report'
 
@@ -7,4 +7,5 @@ urlpatterns = [
     path('', ReportListView.as_view()),
     path('<int:report_id>/', ManageReportView.as_view()),
     path('invalid/<int:report_id>/', InvalidReportView.as_view()),
+    path('cheer-talks/<int:cheer_talk_id>/', BlockCheerTalkView.as_view()),
 ]

--- a/src/sportslive/report/urls.py
+++ b/src/sportslive/report/urls.py
@@ -4,7 +4,7 @@ from report.presentation import ReportListView, BlockCheerTalkView, InvalidRepor
 app_name = 'report'
 
 urlpatterns = [
-    path('all/', ReportListView.as_view()),
+    path('', ReportListView.as_view()),
     path('cheer-talk/<int:report_id>/', BlockCheerTalkView.as_view()),
     path('invalid/<int:report_id>/', InvalidReportView.as_view()),
 ]

--- a/src/sportslive/report/urls.py
+++ b/src/sportslive/report/urls.py
@@ -1,10 +1,10 @@
 from django.urls import path
-from report.presentation import ReportView, BlockCheerTalkView, InvalidReportView
+from report.presentation import ReportListView, BlockCheerTalkView, InvalidReportView
 
 app_name = 'report'
 
 urlpatterns = [
-    path('', ReportView.as_view()),
+    path('all/', ReportListView.as_view()),
     path('cheer-talk/<int:report_id>/', BlockCheerTalkView.as_view()),
     path('invalid/<int:report_id>/', InvalidReportView.as_view()),
 ]

--- a/src/tests/test_report.py
+++ b/src/tests/test_report.py
@@ -30,8 +30,8 @@ class TestReport:
     @pytest.mark.django_db
     def test_block_cheer_talk(self, load_sql_fixture, dependency_fixture):
         member = Member.objects.get(id=1)
-        self._report_service.block_cheer_talk(2)
-        self._report_service.block_cheer_talk(3)
+        self._report_service.manage_report_state_and_cheer_talk_state(2)
+        self._report_service.manage_report_state_and_cheer_talk_state(3)
         assert Report.objects.get(id=2).state == "VALID"
         assert CheerTalk.objects.get(id=4).is_blocked == True
         assert Report.objects.get(id=3).state == "PENDING"

--- a/src/tests/test_report.py
+++ b/src/tests/test_report.py
@@ -11,11 +11,12 @@ class TestReport:
     @pytest.fixture
     def dependency_fixture(self):
         self._report_service = ReportContainer.report_service()
+        self._report_get_service = ReportContainer.report_get_service()
 
     @pytest.mark.django_db
     def test_get_report_info(self, load_sql_fixture, dependency_fixture):
         member = Member.objects.get(id=1)
-        response = self._report_service.get_report_info(member)
+        response = self._report_get_service.get_report_info(member)
         
         assert 'pending' in response
         assert 'isBlocked' in response


### PR DESCRIPTION
### 작업한 내용
- `cheer-talks/<int:cheer_talk_id>/`로 변경되어 cheer_talk의 is_blocked를 관리해주는 api로 변경
- 기존의 `cheer-talks/<int:report_id>/`에 있었던 api는 `<int:report_id>/` url로 변경됨
